### PR TITLE
Refactor sccl tests to not use assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ pip install pre-commit
 or
 ```
 apt-get install pre-commit
+pre-commit install
 ```
 
 ## Interesting ideas for SCCL

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -9,6 +9,11 @@
 #include <stdlib.h>
 #include <string>
 
+#define SCCL_TEST_ASSERT(error)                                                \
+    do {                                                                       \
+        ASSERT_EQ(error, sccl_success);                                        \
+    } while (0)
+
 inline uint32_t get_environment_gpu_index()
 {
     const char *str = getenv("SCCL_TEST_GPU_INDEX");

--- a/test/test_sccl_buffer.cpp
+++ b/test/test_sccl_buffer.cpp
@@ -11,10 +11,9 @@ class buffer_test : public testing::Test
 protected:
     void SetUp() override
     {
-        EXPECT_EQ(sccl_create_instance(&instance), sccl_success);
-        EXPECT_EQ(
-            sccl_create_device(instance, &device, get_environment_gpu_index()),
-            sccl_success);
+        SCCL_TEST_ASSERT(sccl_create_instance(&instance));
+        SCCL_TEST_ASSERT(
+            sccl_create_device(instance, &device, get_environment_gpu_index()));
     }
 
     void TearDown() override
@@ -31,8 +30,8 @@ TEST_F(buffer_test, create_host_buffer)
 {
     size_t size = 0x1000;
     sccl_buffer_t buffer;
-    EXPECT_EQ(sccl_create_buffer(device, &buffer, sccl_buffer_type_host, size),
-              sccl_success);
+    SCCL_TEST_ASSERT(
+        sccl_create_buffer(device, &buffer, sccl_buffer_type_host, size));
     sccl_destroy_buffer(buffer);
 }
 
@@ -40,9 +39,8 @@ TEST_F(buffer_test, create_device_buffer)
 {
     size_t size = 0x1000;
     sccl_buffer_t buffer;
-    EXPECT_EQ(
-        sccl_create_buffer(device, &buffer, sccl_buffer_type_device, size),
-        sccl_success);
+    SCCL_TEST_ASSERT(
+        sccl_create_buffer(device, &buffer, sccl_buffer_type_device, size));
     sccl_destroy_buffer(buffer);
 }
 
@@ -50,9 +48,8 @@ TEST_F(buffer_test, create_shared_buffer)
 {
     size_t size = 0x1000;
     sccl_buffer_t buffer;
-    EXPECT_EQ(
-        sccl_create_buffer(device, &buffer, sccl_buffer_type_shared, size),
-        sccl_success);
+    SCCL_TEST_ASSERT(
+        sccl_create_buffer(device, &buffer, sccl_buffer_type_shared, size));
     sccl_destroy_buffer(buffer);
 }
 
@@ -66,17 +63,15 @@ TEST_F(buffer_test, host_map_buffer)
          {sccl_buffer_type_host_storage, sccl_buffer_type_host_uniform,
           sccl_buffer_type_shared_storage, sccl_buffer_type_shared_uniform}) {
         sccl_buffer_t buffer;
-        EXPECT_EQ(sccl_create_buffer(device, &buffer, type, size),
-                  sccl_success);
+        SCCL_TEST_ASSERT(sccl_create_buffer(device, &buffer, type, size));
 
-        EXPECT_EQ(sccl_host_map_buffer(buffer, &data_ptr, 0, size),
-                  sccl_success);
+        SCCL_TEST_ASSERT(sccl_host_map_buffer(buffer, &data_ptr, 0, size));
 
         /* write to buffer */
         memcpy(data_ptr, test_data.data(), test_data.size() * sizeof(uint32_t));
 
         /* read from buffer */
-        EXPECT_EQ(memcmp(data_ptr, test_data.data(),
+        ASSERT_EQ(memcmp(data_ptr, test_data.data(),
                          test_data.size() * sizeof(uint32_t)),
                   0);
 
@@ -101,17 +96,18 @@ TEST_F(buffer_test, register_host_pointer_buffer)
 
     sccl_buffer_t buffer;
 
-    EXPECT_EQ(
-        sccl_register_host_pointer_buffer(device, &buffer, data_ptr, size),
-        sccl_success);
+    SCCL_TEST_ASSERT(
+        sccl_register_host_pointer_buffer(device, &buffer, data_ptr, size));
 
     /* write to buffer */
     memcpy(data_ptr, test_data.data(), test_data.size() * sizeof(uint32_t));
 
     /* read from buffer */
-    EXPECT_EQ(
+    ASSERT_EQ(
         memcmp(data_ptr, test_data.data(), test_data.size() * sizeof(uint32_t)),
         0);
 
+    /* cleanup */
     sccl_destroy_buffer(buffer);
+    free(data_ptr);
 }

--- a/test/test_sccl_device.cpp
+++ b/test/test_sccl_device.cpp
@@ -8,10 +8,7 @@
 class device_test : public testing::Test
 {
 protected:
-    void SetUp() override
-    {
-        EXPECT_EQ(sccl_create_instance(&instance), sccl_success);
-    }
+    void SetUp() override { SCCL_TEST_ASSERT(sccl_create_instance(&instance)); }
 
     void TearDown() override { sccl_destroy_instance(instance); }
 
@@ -21,18 +18,17 @@ protected:
 TEST_F(device_test, get_device_count)
 {
     uint32_t device_count;
-    EXPECT_EQ(sccl_get_device_count(instance, &device_count), sccl_success);
+    SCCL_TEST_ASSERT(sccl_get_device_count(instance, &device_count));
 }
 
 TEST_F(device_test, create_device)
 {
     uint32_t device_count;
-    EXPECT_EQ(sccl_get_device_count(instance, &device_count), sccl_success);
+    SCCL_TEST_ASSERT(sccl_get_device_count(instance, &device_count));
     EXPECT_GE(device_count, 1);
     sccl_device_t device;
-    EXPECT_EQ(
-        sccl_create_device(instance, &device, get_environment_gpu_index()),
-        sccl_success);
+    SCCL_TEST_ASSERT(
+        sccl_create_device(instance, &device, get_environment_gpu_index()));
 
     sccl_destroy_device(device);
 }
@@ -40,8 +36,8 @@ TEST_F(device_test, create_device)
 TEST_F(device_test, create_device_invalid_index)
 {
     uint32_t device_count;
-    EXPECT_EQ(sccl_get_device_count(instance, &device_count), sccl_success);
+    SCCL_TEST_ASSERT(sccl_get_device_count(instance, &device_count));
     sccl_device_t device;
-    EXPECT_NE(sccl_create_device(instance, &device, device_count + 1),
+    ASSERT_NE(sccl_create_device(instance, &device, device_count + 1),
               sccl_success);
 }

--- a/test/test_sccl_instance.cpp
+++ b/test/test_sccl_instance.cpp
@@ -2,13 +2,14 @@
 
 #include <sccl.h>
 
+#include "common.hpp"
 #include <gtest/gtest.h>
 
 TEST(nccl_instance, create_instance)
 {
 
     sccl_instance_t instance;
-    EXPECT_EQ(sccl_create_instance(&instance), sccl_success);
+    SCCL_TEST_ASSERT(sccl_create_instance(&instance));
 
     sccl_destroy_instance(instance);
 }

--- a/test/test_sccl_stream.cpp
+++ b/test/test_sccl_stream.cpp
@@ -10,10 +10,9 @@ class stream_test : public testing::Test
 protected:
     void SetUp() override
     {
-        EXPECT_EQ(sccl_create_instance(&instance), sccl_success);
-        EXPECT_EQ(
-            sccl_create_device(instance, &device, get_environment_gpu_index()),
-            sccl_success);
+        SCCL_TEST_ASSERT(sccl_create_instance(&instance));
+        SCCL_TEST_ASSERT(
+            sccl_create_device(instance, &device, get_environment_gpu_index()));
     }
 
     void TearDown() override
@@ -29,7 +28,7 @@ protected:
 TEST_F(stream_test, create_stream)
 {
     sccl_stream_t stream;
-    EXPECT_EQ(sccl_create_stream(device, &stream), sccl_success);
+    SCCL_TEST_ASSERT(sccl_create_stream(device, &stream));
     sccl_destroy_stream(stream);
 }
 
@@ -37,15 +36,15 @@ TEST_F(stream_test, dispatch_and_join)
 {
     sccl_stream_t stream;
 
-    EXPECT_EQ(sccl_create_stream(device, &stream), sccl_success);
+    SCCL_TEST_ASSERT(sccl_create_stream(device, &stream));
 
-    EXPECT_EQ(sccl_dispatch_stream(stream), sccl_success);
+    SCCL_TEST_ASSERT(sccl_dispatch_stream(stream));
 
-    EXPECT_EQ(sccl_join_stream(stream), sccl_success);
+    SCCL_TEST_ASSERT(sccl_join_stream(stream));
 
-    EXPECT_EQ(sccl_dispatch_stream(stream), sccl_success);
+    SCCL_TEST_ASSERT(sccl_dispatch_stream(stream));
 
-    EXPECT_EQ(sccl_join_stream(stream), sccl_success);
+    SCCL_TEST_ASSERT(sccl_join_stream(stream));
 
     sccl_destroy_stream(stream);
 }
@@ -58,15 +57,15 @@ TEST_F(stream_test, dispatch_and_join_multiple)
 
     for (size_t i = 0; i < stream_count; ++i) {
         streams.push_back({});
-        EXPECT_EQ(sccl_create_stream(device, &streams.back()), sccl_success);
+        SCCL_TEST_ASSERT(sccl_create_stream(device, &streams.back()));
     }
 
     for (sccl_stream_t stream : streams) {
-        EXPECT_EQ(sccl_dispatch_stream(stream), sccl_success);
+        SCCL_TEST_ASSERT(sccl_dispatch_stream(stream));
     }
 
     for (sccl_stream_t stream : streams) {
-        EXPECT_EQ(sccl_join_stream(stream), sccl_success);
+        SCCL_TEST_ASSERT(sccl_join_stream(stream));
     }
 
     for (sccl_stream_t stream : streams) {
@@ -82,21 +81,21 @@ TEST_F(stream_test, dispatch_and_wait)
 
     for (size_t i = 0; i < stream_count; ++i) {
         streams.push_back({});
-        EXPECT_EQ(sccl_create_stream(device, &streams.back()), sccl_success);
+        SCCL_TEST_ASSERT(sccl_create_stream(device, &streams.back()));
     }
 
     for (sccl_stream_t stream : streams) {
-        EXPECT_EQ(sccl_dispatch_stream(stream), sccl_success);
+        SCCL_TEST_ASSERT(sccl_dispatch_stream(stream));
     }
 
     /* wait for first to trigger for actual test */
-    EXPECT_EQ(sccl_wait_streams(device, streams.data(), stream_count, NULL),
-              sccl_success);
+    SCCL_TEST_ASSERT(
+        sccl_wait_streams(device, streams.data(), stream_count, nullptr));
 
     /* wait for rest so valitaion layer won't complain about unsignaled fences
      */
-    EXPECT_EQ(sccl_wait_streams_all(device, streams.data(), stream_count),
-              sccl_success);
+    SCCL_TEST_ASSERT(
+        sccl_wait_streams_all(device, streams.data(), stream_count));
 
     for (sccl_stream_t stream : streams) {
         sccl_destroy_stream(stream);
@@ -112,18 +111,17 @@ TEST_F(stream_test, dispatch_and_wait_completed_list)
 
     for (size_t i = 0; i < stream_count; ++i) {
         streams.push_back({});
-        EXPECT_EQ(sccl_create_stream(device, &streams.back()), sccl_success);
+        SCCL_TEST_ASSERT(sccl_create_stream(device, &streams.back()));
     }
 
     for (sccl_stream_t stream : streams) {
-        EXPECT_EQ(sccl_dispatch_stream(stream), sccl_success);
+        SCCL_TEST_ASSERT(sccl_dispatch_stream(stream));
     }
 
     /* wait */
     while (true) {
-        EXPECT_EQ(sccl_wait_streams(device, streams.data(), stream_count,
-                                    completed_list.data()),
-                  sccl_success);
+        SCCL_TEST_ASSERT(sccl_wait_streams(device, streams.data(), stream_count,
+                                           completed_list.data()));
         bool not_complete = false;
         for (size_t i = 0; i < stream_count; ++i) {
             if (completed_list[i] == 0) {
@@ -153,15 +151,15 @@ TEST_F(stream_test, dispatch_and_wait_all)
 
     for (size_t i = 0; i < stream_count; ++i) {
         streams.push_back({});
-        EXPECT_EQ(sccl_create_stream(device, &streams.back()), sccl_success);
+        SCCL_TEST_ASSERT(sccl_create_stream(device, &streams.back()));
     }
 
     for (sccl_stream_t stream : streams) {
-        EXPECT_EQ(sccl_dispatch_stream(stream), sccl_success);
+        SCCL_TEST_ASSERT(sccl_dispatch_stream(stream));
     }
 
-    EXPECT_EQ(sccl_wait_streams_all(device, streams.data(), stream_count),
-              sccl_success);
+    SCCL_TEST_ASSERT(
+        sccl_wait_streams_all(device, streams.data(), stream_count));
 
     for (sccl_stream_t stream : streams) {
         sccl_destroy_stream(stream);


### PR DESCRIPTION
* Added SCCL_TEST_ASSERT macro to sccl tests.