### PR TITLE
Add dma-buf support

### DIFF
--- a/examples/examples_common.hpp
+++ b/examples/examples_common.hpp
@@ -10,18 +10,22 @@
 #include <type_traits>
 #include <vulkan/vk_enum_string_helper.h>
 
-#define UNWRAP_VKRESULT(result)                                                \
+#define UNWRAP_VKRESULT(cmd)                                                   \
     do {                                                                       \
-        if (result != VK_SUCCESS) {                                            \
-            fprintf(stderr, "Vulkan error: %s\n", string_VkResult(result));    \
+        VkResult UNWRAP_VKRESULT_result = cmd;                                 \
+        if (UNWRAP_VKRESULT_result != VK_SUCCESS) {                            \
+            fprintf(stderr, "Vulkan error: %s\n",                              \
+                    string_VkResult(UNWRAP_VKRESULT_result));                  \
             exit(EXIT_FAILURE);                                                \
         }                                                                      \
     } while (0)
 
-#define UNWRAP_SCCL_ERROR(error)                                               \
+#define UNWRAP_SCCL_ERROR(cmd)                                                 \
     do {                                                                       \
-        if (error != sccl_success) {                                           \
-            fprintf(stderr, "SCCL error: %s\n", sccl_get_error_string(error)); \
+        sccl_error_t UNWRAP_SCCL_ERROR_error = cmd;                            \
+        if (UNWRAP_SCCL_ERROR_error != sccl_success) {                         \
+            fprintf(stderr, "SCCL error: %s\n",                                \
+                    sccl_get_error_string(UNWRAP_SCCL_ERROR_error));           \
             exit(EXIT_FAILURE);                                                \
         }                                                                      \
     } while (0)
@@ -161,12 +165,12 @@ template <class Container> void print_container(const Container &container)
 }
 
 template <typename T>
-bool float_equal(T a, T b,
-                        T epsilon = std::numeric_limits<T>::epsilon())
+bool float_equal(T a, T b, T epsilon = std::numeric_limits<T>::epsilon())
 {
     T abs_th = std::numeric_limits<T>::min();
     T diff = std::abs(a - b);
-    T norm = std::min((std::fabs(a) + std::fabs(b)), std::numeric_limits<T>::max());
+    T norm =
+        std::min((std::fabs(a) + std::fabs(b)), std::numeric_limits<T>::max());
     return diff < std::max(abs_th, epsilon * norm);
 }
 

--- a/src/sccl/device.c
+++ b/src/sccl/device.c
@@ -144,6 +144,7 @@ static sccl_error_t determine_device_extensions(
     size_t *device_extension_names_count, bool *host_pointer_supported,
     bool *dmabuf_buffer_supported)
 {
+    (void)all_wanted_device_extension_names;
     assert(all_wanted_device_extension_names_count ==
            sizeof(all_wanted_device_extension_names) / sizeof(const char *));
 

--- a/src/sccl/device.h
+++ b/src/sccl/device.h
@@ -14,6 +14,19 @@ struct sccl_device {
     VkDevice device;
     uint32_t compute_queue_family_index;
     uint32_t transfer_queue_family_index;
+
+    /* supported capabilities */
+    bool host_pointer_supported;
+    bool dmabuf_buffer_supported;
+
+    /* dynamically loaded device extension API calls */
+    PFN_vkGetMemoryFdKHR
+        pfn_vk_get_memory_fd_khr; /**< only valid if `dmabuf_buffer_supported`
+                                     is true. */
+    PFN_vkGetMemoryFdPropertiesKHR
+        pfn_vk_get_memory_fd_properties_khr; /**< only valid if
+                                                `dmabuf_buffer_supported` is
+                                                true. */
 };
 
 bool has_seperate_transfer_queue(const sccl_device_t device);

--- a/src/sccl/error.h
+++ b/src/sccl/error.h
@@ -9,48 +9,55 @@
 #include <stdio.h>
 #include <vulkan/vk_enum_string_helper.h>
 
-#define UNWRAP_VKRESULT(result)                                                \
+#define UNWRAP_VKRESULT(cmd)                                                   \
     do {                                                                       \
-        if (result != VK_SUCCESS) {                                            \
-            fprintf(stderr, "Vulkan error: %s\n", string_VkResult(result));    \
+        VkResult UNWRAP_VKRESULT_result = cmd;                                 \
+        if (UNWRAP_VKRESULT_result != VK_SUCCESS) {                            \
+            fprintf(stderr, "Vulkan error: %s\n",                              \
+                    string_VkResult(UNWRAP_VKRESULT_result));                  \
             exit(EXIT_FAILURE);                                                \
         }                                                                      \
     } while (0)
 
 /* Check `VkResult`, if success then continue, else return
  * `sccl_unhandled_vulkan_error` */
-#define CHECK_VKRESULT_RET(result)                                             \
+#define CHECK_VKRESULT_RET(cmd)                                                \
     do {                                                                       \
-        if (result != VK_SUCCESS) {                                            \
+        VkResult CHECK_VKRESULT_RET_result = cmd;                              \
+        if (CHECK_VKRESULT_RET_result != VK_SUCCESS) {                         \
             return sccl_unhandled_vulkan_error;                                \
         }                                                                      \
     } while (0)
 
 /* Check `VkResult`, if success then continue, else goto `goto_label`, , store
  * sccl error in `store_sccl_error` if error */
-#define CHECK_VKRESULT_GOTO(result, goto_label, store_sccl_error)              \
+#define CHECK_VKRESULT_GOTO(cmd, goto_label, store_sccl_error)                 \
     do {                                                                       \
-        if (result != VK_SUCCESS) {                                            \
-            fprintf(stderr, "Vulkan error: %s\n", string_VkResult(result));    \
+        VkResult CHECK_VKRESULT_GOTO_result = cmd;                             \
+        if (CHECK_VKRESULT_GOTO_result != VK_SUCCESS) {                        \
+            fprintf(stderr, "Vulkan error: %s\n",                              \
+                    string_VkResult(CHECK_VKRESULT_GOTO_result));              \
             store_sccl_error = sccl_unhandled_vulkan_error;                    \
             goto goto_label;                                                   \
         }                                                                      \
     } while (0)
 
 /* Check `sccl_error_t`, if success then continue, else return error */
-#define CHECK_SCCL_ERROR_RET(error)                                            \
+#define CHECK_SCCL_ERROR_RET(cmd)                                              \
     do {                                                                       \
-        if (error != sccl_success) {                                           \
-            return error;                                                      \
+        sccl_error_t CHECK_SCCL_ERROR_RET_error = cmd;                         \
+        if (CHECK_SCCL_ERROR_RET_error != sccl_success) {                      \
+            return CHECK_SCCL_ERROR_RET_error;                                 \
         }                                                                      \
     } while (0)
 
 /* Check `sccl_error_t`, if success then continue, else goto `goto_label`, store
  * sccl error in `store_sccl_error` if error */
-#define CHECK_SCCL_ERROR_GOTO(error, goto_label, store_sccl_error)             \
+#define CHECK_SCCL_ERROR_GOTO(cmd, goto_label, store_sccl_error)               \
     do {                                                                       \
-        if (error != sccl_success) {                                           \
-            store_sccl_error = error;                                          \
+        sccl_error_t CHECK_SCCL_ERROR_GOTO_error = cmd;                        \
+        if (CHECK_SCCL_ERROR_GOTO_error != sccl_success) {                     \
+            store_sccl_error = CHECK_SCCL_ERROR_GOTO_error;                    \
             goto goto_label;                                                   \
         }                                                                      \
     } while (0)

--- a/src/sccl/instance.c
+++ b/src/sccl/instance.c
@@ -101,7 +101,8 @@ static sccl_error_t check_validation_layer_support(bool *supported)
 
         for (size_t i = 0; i < layer_count; ++i) {
             VkLayerProperties *layer_properties = &available_layers[i];
-            if (strcmp(layer_name, layer_properties->layerName) == 0) {
+            if (strncmp(layer_name, layer_properties->layerName,
+                        VK_MAX_EXTENSION_NAME_SIZE) == 0) {
                 layer_found = true;
                 break;
             }

--- a/src/sccl/sccl.h
+++ b/src/sccl/sccl.h
@@ -362,11 +362,30 @@ sccl_error_t sccl_create_buffer(const sccl_device_t device,
  * `sccl_device_properties_t::min_external_buffer_host_pointer_alignment`.
  *
  * @return An `sccl_error_t` code indicating the success or failure of the
- * buffer registration.
+ * buffer registration. `sccl_unsupported_error` is returned if device does not
+ * support host pointer buffers.
  */
-sccl_error_t sccl_register_host_pointer_buffer(const sccl_device_t device,
-                                               sccl_buffer_t *buffer,
-                                               void *host_pointer, size_t size);
+sccl_error_t sccl_create_host_pointer_buffer(const sccl_device_t device,
+                                             sccl_buffer_t *buffer,
+                                             void *host_pointer, size_t size);
+
+/**
+ * @return An `sccl_error_t` code indicating the success or failure of the
+ * buffer creation. `sccl_unsupported_error` is returned if device does not
+ * support dmabuf buffers.
+ */
+sccl_error_t sccl_create_dmabuf_buffer(const sccl_device_t device,
+                                       sccl_buffer_t *buffer,
+                                       sccl_buffer_type_t type, size_t size);
+
+/**
+ * @note `out_fd` has to be closed when cleaning up.
+ */
+sccl_error_t sccl_export_dmabuf_buffer(const sccl_buffer_t buffer, int *out_fd);
+
+sccl_error_t sccl_import_dmabuf_buffer(const sccl_device_t device,
+                                       sccl_buffer_t *buffer, int in_fd,
+                                       sccl_buffer_type_t type, size_t size);
 
 /**
  * @brief Destroy the specified buffer.

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -9,9 +9,10 @@
 #include <stdlib.h>
 #include <string>
 
-#define SCCL_TEST_ASSERT(error)                                                \
+#define SCCL_TEST_ASSERT(cmd)                                                  \
     do {                                                                       \
-        ASSERT_EQ(error, sccl_success);                                        \
+        sccl_error_t SCCL_TEST_ASSERT_error = cmd;                             \
+        ASSERT_EQ(SCCL_TEST_ASSERT_error, sccl_success);                       \
     } while (0)
 
 inline uint32_t get_environment_gpu_index()


### PR DESCRIPTION
* Add sccl_create_dmabuf_buffer, sccl_export_dmabuf_buffer and sccl_import_dmabuf_buffer.
* Rename sccl_register_host_pointer_buffer to sccl_create_host_pointer_buffer.
* Consolidate create buffer implementations in create_buffer_internal.
* Fix CHECK/UNWRAP macros so they only evaluate cmd once.
* Add optional device extension capability in sccl_device_t (dmabuf is not supported on all GPUs).
* Make buffer tests skip if buffer is not supported on device.