### PR TITLE
Add environment variable SCCL_TEST_PLATFORM_DOCKER

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -36,5 +36,5 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: ctest -C ${{matrix.build_type}}
+      run: SCCL_TEST_PLATFORM_DOCKER=1 ctest -C ${{matrix.build_type}}
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,15 @@ Sivert Collective Compute Library (SCCL) is a wrapper library for simplifying wr
 * C17 compatible compiler
 * C++20 compatible compiler
 * Vulkan SDK https://vulkan.lunarg.com/
-* clang-tidy-15
+* clang-tidy-19
 
 ### Run tests
 Run this is build directory:
 ```
 make -j $(nproc) && SCCL_ENABLE_VALIDATION_LAYERS=1 SCCL_ASSERT_ON_VALIDATION_ERROR=1 SCCL_TEST_GPU_INDEX=0 make test_verbose  && cat test/Testing/Temporary/LastTest.log 
 ```
+
+`SCCL_TEST_PLATFORM_DOCKER=1` will disable dmabuf tests, this is useful for docker containers, as dmabuf does not work well inside containers.
 
 ## Pre-commit
 https://pre-commit.com/

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -37,6 +37,17 @@ inline const char *get_environment_shaders_dir()
     return str;
 }
 
+inline bool get_environment_platform_docker()
+{
+    const char *str = getenv("SCCL_TEST_PLATFORM_DOCKER");
+    if (str == NULL) {
+        return false;
+    }
+    int value = std::atoi(str);
+    printf("environment - SCCL_TEST_PLATFORM_DOCKER = %d\n", value);
+    return static_cast<bool>(value);
+}
+
 inline std::optional<std::string> read_file(const char *filepath)
 {
     printf("filepath = %s\n", filepath);

--- a/test/test_sccl_buffer.cpp
+++ b/test/test_sccl_buffer.cpp
@@ -119,6 +119,12 @@ TEST_F(buffer_test, create_external_host_pointer_buffer)
 
 TEST_F(buffer_test, create_dmabuf_buffer)
 {
+    /* dmabuf does not work well inside docker containers atm */
+    if (get_environment_platform_docker()) {
+        GTEST_SKIP() << "Skipping test, dmabuf can't be tested inside a docker "
+                        "container";
+    }
+
     /* query import alignment requirement */
     sccl_device_properties_t device_properties = {};
     sccl_get_device_properties(device, &device_properties);

--- a/test/test_sccl_shader.cpp
+++ b/test/test_sccl_shader.cpp
@@ -523,9 +523,34 @@ TEST_F(shader_test, shader_copy_buffer_concurrent_streams)
     }
 }
 
+static bool is_buffer_type_dmabuf(sccl_buffer_type_t type)
+{
+    switch (type) {
+    case sccl_buffer_type_host_dmabuf_storage:
+    case sccl_buffer_type_device_dmabuf_storage:
+    case sccl_buffer_type_shared_dmabuf_storage:
+    case sccl_buffer_type_host_dmabuf_uniform:
+    case sccl_buffer_type_device_dmabuf_uniform:
+    case sccl_buffer_type_shared_dmabuf_uniform:
+    case sccl_buffer_type_external_dmabuf_storage:
+    case sccl_buffer_type_external_dmabuf_uniform:
+        return true;
+    default:
+        return false;
+    }
+}
+
 void shader_test::buffer_passthrough_test(sccl_buffer_type_t source_type,
                                           sccl_buffer_type_t target_type)
 {
+
+    if (get_environment_platform_docker() &&
+        (is_buffer_type_dmabuf(source_type) ||
+         is_buffer_type_dmabuf(target_type))) {
+        /* skip, dmabuf does not work well inside docker containers */
+        return;
+    }
+
     std::string shader_source =
         read_test_shader("copy_buffer_shader.spv").value();
 


### PR DESCRIPTION
This option signals if the test suite is running inside a docker container. Currently this option will disable dmabuf tests since they don't work well inside containers currently.